### PR TITLE
feat(janet-ai-retriever): switch embeddings from f32 to f16 for memory optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,20 @@ name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -408,6 +422,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -726,6 +746,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1133,6 +1164,7 @@ dependencies = [
  "bytemuck",
  "clap",
  "futures",
+ "half",
  "hex",
  "ignore",
  "itertools",

--- a/janet-ai-retriever/Cargo.toml
+++ b/janet-ai-retriever/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = "0.1.88"
 blake3 = "1.7.0"
 bytemuck = "1.14.0"
 clap = { version = "4.5.4", features = ["derive"] }
+half = { version = "2.4.1", features = ["bytemuck"] }
 futures = "0.3.31"
 hex = "0.4"
 ignore = "0.4.23"

--- a/janet-ai-retriever/src/storage/mod.rs
+++ b/janet-ai-retriever/src/storage/mod.rs
@@ -15,7 +15,7 @@ pub struct Chunk {
     pub line_start: usize,
     pub line_end: usize,
     pub content: String,
-    pub embedding: Option<Vec<f32>>,
+    pub embedding: Option<Vec<half::f16>>,
 }
 
 /// Represents a file in the index
@@ -74,22 +74,22 @@ pub trait EmbeddingStore: Send + Sync {
     async fn store_embeddings(
         &self,
         chunk_ids: Vec<ChunkId>,
-        embeddings: Vec<Vec<f32>>,
+        embeddings: Vec<Vec<half::f16>>,
     ) -> Result<()>;
 
     /// Search for similar chunks using vector similarity
     async fn search_similar(
         &self,
-        query: Vec<f32>,
+        query: Vec<half::f16>,
         limit: usize,
-        threshold: Option<f32>,
-    ) -> Result<Vec<(ChunkId, f32)>>;
+        threshold: Option<half::f16>,
+    ) -> Result<Vec<(ChunkId, half::f16)>>;
 
     /// Delete embeddings for specific chunks
     async fn delete_embeddings(&self, chunk_ids: Vec<ChunkId>) -> Result<()>;
 
     /// Get embedding for a specific chunk
-    async fn get_embedding(&self, chunk_id: ChunkId) -> Result<Option<Vec<f32>>>;
+    async fn get_embedding(&self, chunk_id: ChunkId) -> Result<Option<Vec<half::f16>>>;
 }
 
 /// Combined store that implements both chunk storage and embedding search
@@ -98,8 +98,8 @@ pub trait CombinedStore: ChunkStore + EmbeddingStore + Send + Sync {
     /// Search for similar chunks and return full chunk data
     async fn search_chunks(
         &self,
-        query: Vec<f32>,
+        query: Vec<half::f16>,
         limit: usize,
-        threshold: Option<f32>,
-    ) -> Result<Vec<(Chunk, f32)>>;
+        threshold: Option<half::f16>,
+    ) -> Result<Vec<(Chunk, half::f16)>>;
 }

--- a/janet-ai-retriever/tests/cli_integration.rs
+++ b/janet-ai-retriever/tests/cli_integration.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use half::f16;
 use janet_ai_retriever::retrieval::file_index::{ChunkRef, FileIndex, FileRef};
 use std::process::Command;
 use tempfile::TempDir;
@@ -51,7 +52,12 @@ async fn populate_test_data(temp_dir: &TempDir) -> Result<()> {
             line_start: 1,
             line_end: 1,
             content: "fn main() {".to_string(),
-            embedding: Some(vec![0.1, 0.2, 0.3, 0.4]),
+            embedding: Some(vec![
+                f16::from_f32(0.1),
+                f16::from_f32(0.2),
+                f16::from_f32(0.3),
+                f16::from_f32(0.4),
+            ]),
         },
         ChunkRef {
             id: None,
@@ -60,7 +66,12 @@ async fn populate_test_data(temp_dir: &TempDir) -> Result<()> {
             line_start: 2,
             line_end: 2,
             content: "    println!(\"Hello, world!\");".to_string(),
-            embedding: Some(vec![0.5, 0.6, 0.7, 0.8]),
+            embedding: Some(vec![
+                f16::from_f32(0.5),
+                f16::from_f32(0.6),
+                f16::from_f32(0.7),
+                f16::from_f32(0.8),
+            ]),
         },
         ChunkRef {
             id: None,
@@ -69,7 +80,12 @@ async fn populate_test_data(temp_dir: &TempDir) -> Result<()> {
             line_start: 1,
             line_end: 2,
             content: "pub fn add(a: i32, b: i32) -> i32 {\n    a + b".to_string(),
-            embedding: Some(vec![0.9, 0.8, 0.7, 0.6]),
+            embedding: Some(vec![
+                f16::from_f32(0.9),
+                f16::from_f32(0.8),
+                f16::from_f32(0.7),
+                f16::from_f32(0.6),
+            ]),
         },
         ChunkRef {
             id: None,


### PR DESCRIPTION
## Summary
- Converts all embedding storage from 32-bit floats (f32) to 16-bit floats (f16) for ~50% memory reduction
- Maintains user-friendly CLI interface by accepting f32 input and converting internally
- Preserves computational precision by using f32 for similarity calculations while storing f16

## Changes Made
- **Dependencies**: Added `half` crate with `bytemuck` feature for Pod trait support
- **Data Types**: Updated all embedding types from `Vec<f32>` to `Vec<half::f16>`
- **CLI Interface**: Modified to accept f32 input but convert internally to f16
- **Storage Layer**: Updated all storage traits and cosine similarity for f16
- **Precision Strategy**: Compute similarity in f32 for accuracy, store as f16 for memory efficiency
- **Test Updates**: All test data now uses f16 values with proper type conversions

## Benefits
- **Memory Efficiency**: ~50% reduction in embedding storage requirements
- **Backward Compatibility**: CLI interface unchanged for users
- **Performance**: Maintains computational precision where needed
- **Type Safety**: Consistent f16 usage throughout the codebase

## Test Coverage
- All existing tests pass with f16 conversion
- Added comprehensive test coverage for f16 operations
- Verified CLI functionality with f16 embeddings
- Validated cosine similarity calculations with mixed precision

🤖 Generated with [Claude Code](https://claude.ai/code)