### PR TITLE
feat: replace TaskQueue Arc<Mutex> with flume channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
+ "nanorand",
  "spin",
 ]
 
@@ -1798,6 +1799,7 @@ dependencies = [
  "bytemuck",
  "chrono",
  "clap",
+ "flume",
  "futures",
  "half",
  "hex",
@@ -2082,6 +2084,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]

--- a/janet-ai-retriever/Cargo.toml
+++ b/janet-ai-retriever/Cargo.toml
@@ -11,6 +11,7 @@ blake3 = "1.7.0"
 bytemuck = "1.14.0"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.4", features = ["derive"] }
+flume = "0.11"
 half = { version = "2.4.1", features = ["bytemuck"] }
 futures = "0.3.31"
 hex = "0.4"


### PR DESCRIPTION
## Summary
- Replace complex Arc<Mutex<BinaryHeap>> + tokio::mpsc with simple flume bounded channel
- Remove 45+ lines of mutex coordination and async processor spawning  
- Eliminate potential deadlock scenarios in read-only mode
- Simplify API: pop_task() -> recv_task(), remove start_processor()/shutdown()

## Test plan
- [x] All existing tests pass
- [x] TaskQueue unit tests updated for new API
- [x] Integration tests verify functionality
- [x] No clippy warnings or formatting issues

## Impact
Net reduction: **434 → 311 lines (-123 lines, -28%)**

This addresses the deadlock issues discussed in the architecture review by removing complex mutex coordination that could cause problems in read-only mode and multi-instance scenarios.

🤖 Generated with [Claude Code](https://claude.ai/code)